### PR TITLE
Fix formatting of and set configs for IntelliJ IDEs, VSCode and editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,7 @@
+# JetBrains IDEs (Webstorm) specific properties: ij_*
+# They are ignored by other IDEs like VSCode and should help apply the same format across IDEs.
+# See discussion in https://github.com/markusstraub/radlkarte/pull/30 for details.
+
 root = true
 
 [*]
@@ -5,14 +9,28 @@ end_of_line = lf
 insert_final_newline = true
 ij_formatter_off_tag = @formatter:off
 ij_formatter_on_tag = @formatter:on
+ij_formatter_tags_enabled = true
+ij_visual_guides = 80, 120
 
 [*.{js,json,yml}]
 charset = utf-8
 indent_style = space
 indent_size = 2
+ij_javascript_spaces_within_object_literal_braces = true
+ij_javascript_spaces_within_object_type_braces = true
+
+[*.{css,scss}]
+charset = utf-8
+indent_style = space
+indent_size = 2
+ij_scss_blank_lines_around_nested_selector = 1
+ij_scss_blank_lines_between_blocks = 1
+
+[.vscode/**.json]
+indent_size = 4
 
 [*.html]
-# JetBrains IDEs (Webstorm) specific:
+ij_continuation_indent_size = 4
+ij_html_align_attributes = false
 # Add space to void elements (self-closing tags) to keep status quo and format the same way as VSCode in this project.
-# See discussion in https://github.com/markusstraub/radlkarte/pull/30 for details.
 ij_html_space_inside_empty_tag = true

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /data/osm-overpass
 
 .vscode
+!.vscode/settings.json
+!.vscode/extensions.json
 __pycache__
 .pytest_cache
 test_output.geojson

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "editorconfig.editorconfig"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "editor.formatOnSave": true,
-    "files.insertFinalNewline": true
+    "files.insertFinalNewline": true,
+    "css.format.spaceAroundSelectorSeparator": true
 }

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <meta property="og:url" content="https://www.radlkarte.at" />
   <meta property="og:image" content="https://www.radlkarte.at/css/radlkarte-banner.jpg" />
   <meta property="og:description"
-    content="Viele Wege führen zum Ziel. Finden Sie Ihren optimalen Weg durch die Stadt mit der Radlkarte der Radlobby. Auf zu neuen Ufern, unbekannten Gegenden, und neuen Alternativen zu Ihren alltäglichen Routen." />
+      content="Viele Wege führen zum Ziel. Finden Sie Ihren optimalen Weg durch die Stadt mit der Radlkarte der Radlobby. Auf zu neuen Ufern, unbekannten Gegenden, und neuen Alternativen zu Ihren alltäglichen Routen." />
 
   <title>Radlkarte - Entspannt durch Klagenfurt, Linz, Rheintal, Schwarzatal, Steyr und Wien</title>
 
@@ -557,7 +557,7 @@
         </p>
         <div id="matomo-opt-out"></div>
         <script
-          src="https://matomo.radlobby.at/index.php?module=CoreAdminHome&action=optOutJS&divId=matomo-opt-out&language=de&showIntro=0"></script>
+            src="https://matomo.radlobby.at/index.php?module=CoreAdminHome&action=optOutJS&divId=matomo-opt-out&language=de&showIntro=0"></script>
         <h3>Ihre Rechte</h3>
         <p>
           Ihnen stehen nach DSGVO die Rechte auf Auskunft, Berichtigung, Löschung, Einschränkung,

--- a/radlkarte.css
+++ b/radlkarte.css
@@ -1,218 +1,218 @@
 body {
-	padding: 0;
-	margin: 0;
+  padding: 0;
+  margin: 0;
 }
 
 html,
 body,
 #map {
-	height: 100%;
-	width: 100%;
+  height: 100%;
+  width: 100%;
 }
 
 #radlobby-logo {
-	position: fixed;
-	right: 0px;
-	bottom: 10px;
-	z-index: 900;
+  position: fixed;
+  right: 0px;
+  bottom: 10px;
+  z-index: 900;
 }
 
 #radlobby-logo img {
-	padding: 5px;
-	width: 100px;
+  padding: 5px;
+  width: 100px;
 }
 
 @media (max-width: 600px) {
-	#radlobby-logo img {
-		width: 50px;
-	}
+  #radlobby-logo img {
+    width: 50px;
+  }
 }
 
 
 .leaflet-container {
-	background-color: #fff;
+  background-color: #fff;
 }
 
 h1,
 h2,
 h3,
 h4 {
-	font-family: 'Museo 500 Regular', sans-serif;
-	color: #004B67;
+  font-family: 'Museo 500 Regular', sans-serif;
+  color: #004B67;
 }
 
 h5,
 a {
-	color: #004B67;
+  color: #004B67;
 }
 
 h5,
 p,
 li {
-	font-family: Roboto, arial, sans-serif;
+  font-family: Roboto, arial, sans-serif;
 }
 
 h1 {
-	font-size: 100%;
-	margin-top: 0;
-	margin-bottom: 0.2em;
-	color: #B8CC24;
+  font-size: 100%;
+  margin-top: 0;
+  margin-bottom: 0.2em;
+  color: #B8CC24;
 }
 
 h3 {
-	font-size: 115%;
+  font-size: 115%;
 }
 
 h4 {
-	font-size: 110%;
+  font-size: 110%;
 }
 
 strong {
-	font-weight: bold;
+  font-weight: bold;
 }
 
 input {
-	accent-color: #004B67;
+  accent-color: #004B67;
 }
 
 .leaflet-sidebar {
-	font-size: medium;
+  font-size: medium;
 }
 
 .leaflet-sidebar-header,
-.leaflet-sidebar-tabs>ul>li.active {
-	background-color: #B8CC24;
-	color: #fff
+.leaflet-sidebar-tabs > ul > li.active {
+  background-color: #B8CC24;
+  color: #fff
 }
 
-.leaflet-sidebar-tabs>ul>li.active>a>i {
-	color: #fff;
+.leaflet-sidebar-tabs > ul > li.active > a > i {
+  color: #fff;
 }
 
 .leaflet-sidebar-pane a,
 .leaflet-sidebar-pane a:visited,
 .leaflet-sidebar-pane a:active,
 .leaflet-control-attribution a {
-	color: #004B67;
-	/* text-decoration: none; */
+  color: #004B67;
+  /* text-decoration: none; */
 }
 
 a:hover {
-	color: white !important;
-	background-color: #B8CC24 !important;
-	/* text-decoration: underline; */
+  color: white !important;
+  background-color: #B8CC24 !important;
+  /* text-decoration: underline; */
 }
 
 ul.legend-leftified {
-	padding-left: 0;
+  padding-left: 0;
 }
 
 ul.legend li {
-	list-style-type: none;
-	margin-bottom: 0.5em;
+  list-style-type: none;
+  margin-bottom: 0.5em;
 }
 
 div.legend {
-	width: 230px;
-	height: 10px;
-	border-radius: 5px;
+  width: 230px;
+  height: 10px;
+  border-radius: 5px;
 }
 
 div.legend-main {
-	vertical-align: middle;
-	background-color: #999;
+  vertical-align: middle;
+  background-color: #999;
 }
 
 div.legend-regional {
-	background-color: #999;
-	height: 4px;
+  background-color: #999;
+  height: 4px;
 }
 
 div.legend-calm {
-	background-color: #004B67;
+  background-color: #004B67;
 }
 
 div.legend-medium {
-	background-color: #51A4B6;
+  background-color: #51A4B6;
 }
 
 div.legend-stressful {
-	background-color: #FF6600;
+  background-color: #FF6600;
 }
 
 div.legend-oneway {
-	width: 0;
-	height: 0;
-	border-style: solid;
-	border-width: 15px 0 15px 15px;
-	border-color: transparent transparent transparent #999;
-	margin-left: 10px;
-	margin-right: 35px;
-	border-radius: 0;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 15px 0 15px 15px;
+  border-color: transparent transparent transparent #999;
+  margin-left: 10px;
+  margin-right: 35px;
+  border-radius: 0;
 }
 
 div.legend-unpaved {
-	background: repeating-linear-gradient(90deg,
-			#999 0,
-			#999 20px,
-			#fff 20px,
-			#fff 30px);
+  background: repeating-linear-gradient(90deg,
+  #999 0,
+  #999 20px,
+  #fff 20px,
+  #fff 30px);
 }
 
 div.legend-steep {
-	height: 25px;
-	background: repeating-linear-gradient(90deg,
-			transparent 0,
-			transparent 9px,
-			#999 9px,
-			#999 11px,
-			transparent 11px,
-			transparent 30px);
+  height: 25px;
+  background: repeating-linear-gradient(90deg,
+  transparent 0,
+  transparent 9px,
+  #999 9px,
+  #999 11px,
+  transparent 11px,
+  transparent 30px);
 }
 
 div.legend-container {
-	display: grid;
-	align-items: center;
+  display: grid;
+  align-items: center;
 }
 
 div.legend-container div {
-	grid-column: 1;
-	grid-row: 1;
-	display: flex;
+  grid-column: 1;
+  grid-row: 1;
+  display: flex;
 }
 
 ul.legend li img {
-	float: right;
-	margin-left: 0.5em;
-	margin-bottom: 0.5em;
+  float: right;
+  margin-left: 0.5em;
+  margin-bottom: 0.5em;
 }
 
 .leaflet-popup-content p,
 .leaflet-popup-content ul {
-	margin-top: 0;
-	margin-bottom: 0.2em;
+  margin-top: 0;
+  margin-bottom: 0.2em;
 }
 
 .leaflet-popup-content h2 {
-	font-size: 100%;
-	margin-top: 0;
-	margin-bottom: 0.2em;
+  font-size: 100%;
+  margin-top: 0;
+  margin-bottom: 0.2em;
 }
 
 .leaflet-popup-content .sidenote {
-	color: dimgray;
-	font-size: 85%;
-	margin-bottom: 0;
+  color: dimgray;
+  font-size: 85%;
+  margin-bottom: 0;
 }
 
 .leaflet-popup-content .sidenote a {
-	color: dimgray;
+  color: dimgray;
 }
 
 span.transitLine {
-	color: #fff;
-	font-weight: bold;
-	padding: 0.2em;
+  color: #fff;
+  font-weight: bold;
+  padding: 0.2em;
 }
 
 /*

--- a/radlkarte.js
+++ b/radlkarte.js
@@ -83,7 +83,9 @@ rkGlobal.configurations = {
     nextbikeUrl: 'https://maps.nextbike.net/maps/nextbike.json?domains=wr,la&bikes=false',
   },
 };
-rkGlobal.pageHeader = function () { return $('h1'); }
+rkGlobal.pageHeader = function () {
+  return $('h1');
+}
 
 function debug(obj) {
   if (rkGlobal.debug) {
@@ -301,9 +303,9 @@ function clearAndLoadNextbike(url) {
   });
 }
 
-/** 
+/**
  * @param domain 2-letter Nextbike domain for determining special icons (optional).
- * @param place JSON from Nextbike API describing a bike-share station. 
+ * @param place JSON from Nextbike API describing a bike-share station.
  */
 function createNextbikeMarkerIncludingPopup(domain, place, cityUrl) {
   let description = '<h2>' + place.name + '</h2>';
@@ -330,11 +332,15 @@ function createMarkerIncludingPopup(latLng, icon, description, altText) {
     alt: altText,
   });
   marker.bindPopup(`<article class="tooltip">${description}</article>`, { closeButton: true });
-  marker.on('mouseover', function () { marker.openPopup(); });
+  marker.on('mouseover', function () {
+    marker.openPopup();
+  });
   // adding a mouseover event listener causes a problem with touch browsers:
   // then two taps are required to show the marker.
   // explicitly adding the click event listener here solves the issue
-  marker.on('click', function () { marker.openPopup(); });
+  marker.on('click', function () {
+    marker.openPopup();
+  });
   return marker;
 }
 
@@ -451,7 +457,11 @@ function clearAndLoadBasicOsmPoi(type, region) {
         }
         // NOTE: state left empty because school holidays are likely not relevant (not a single mapped instance in our data set)
         // noinspection JSPotentiallyInvalidConstructorUsage
-        const oh = new opening_hours(opening_hours_value, { lat: latLng.lat, lon: latLng.lng, address: { country_code: "at", state: "" } });
+        const oh = new opening_hours(opening_hours_value, {
+          lat: latLng.lat,
+          lon: latLng.lng,
+          address: { country_code: "at", state: "" }
+        });
         currentlyOpen = oh.getState();
         const openText = currentlyOpen ? "jetzt geöffnet" : "derzeit geschlossen";
         let items = oh.prettifyValue({ conf: { locale: 'de' }, }).split(";");


### PR DESCRIPTION
(Follow-up von #30)

Ich hab jetzt mal etwas rumprobiert und bin zu folgendem Ergebnis gekommen:

- EditorConfig ist in VSCode nicht automatisch installiert, daher habe ich es via `.vscode/extensions.json` als Recommendation eingefügt und im Gitignore als Ausnahme eingetragen.
- Es gibt zwar eine `.vscode/settings.json` für projektspezifische Einstellungen im Repo, aber der gesamte `.vscode` Ordner ist im Gitignore. Habe sie daher als Ausnahme eingetragen, da ich folgende Einstellung hinzufügen musste: `css.format.spaceAroundSelectorSeparator: true` (da es so erstens besser lesbar ist –  `selector > subselector` anstatt `selector>subselector` – und ich zweitens in JetBrains keine Einstellung gefunden habe um es wie VSCode zu formattieren).
- In der EditorConfig habe ich ein paar Einstellungen hinzugefügt die für VSCode und JetBrains gelten sowie ein paar nur für JetBrains.

Das produziert jetzt nochmal einen Diff in der CSS und JS Datei, aber danach formattieren mein JetBrains (WebStorm) und mein VSCode bis auf 2 Ausnahmen identisch.

CSS:
![image](https://github.com/markusstraub/radlkarte/assets/8668756/fe8a748a-3982-450b-8e26-9083aa4c3ce8)

HTML:
![image](https://github.com/markusstraub/radlkarte/assets/8668756/6e45abca-39ea-4c5d-adcb-4b8a663223f7)

Dazu finde ich weder in JetBrains noch in VSCode eine Möglichkeit, das für die jeweils andere IDE passend einzustellen. Wenn diese bekannt sind und man darauf achtet, die nicht mit zu committen, kann ich damit leben.

Für mich wäre interessant, ob euer VSCode jetzt gleich formattiert (also außer diesen beiden Punkten keinen weiteren Diff erzeugt) oder was es noch anders macht, @markusstraub @000panther.

Was ich mir noch anschauen muss, ist die Formattierung von Markdown Dateien.